### PR TITLE
Update language namespace to avoid conflicts with sakai content item

### DIFF
--- a/plugin/webapps/library/editor/ckextraplugins/warpwirecontentitem/lang/en.js
+++ b/plugin/webapps/library/editor/ckextraplugins/warpwirecontentitem/lang/en.js
@@ -10,7 +10,7 @@ CKEDITOR.addPluginLang = function( plugin, lang, obj )
     CKEDITOR.plugins.setLang( plugin, lang, obj );
 }
 
-CKEDITOR.addPluginLang('contentitem','en',
+CKEDITOR.addPluginLang('warpwirecontentitem','en',
     {
 	'tooltip':'Insert Content Item'
     }


### PR DESCRIPTION
We started having namespace conflicts after our 21 upgrade. I think it's related to both the sakai contentitem plugin and the warpwirecontentitem plugin using the contentitem namespace. I'm working on some sakai upstream changes to help with this as well but thought this might be a worthy change on the ww end.